### PR TITLE
fix: support aggregation-based filtering in ElasticsearchService using ResponseModel

### DIFF
--- a/src/main/java/org/cdpg/dx/database/elastic/model/AccessPolicyQueryDecorator.java
+++ b/src/main/java/org/cdpg/dx/database/elastic/model/AccessPolicyQueryDecorator.java
@@ -1,0 +1,67 @@
+package org.cdpg.dx.database.elastic.model;
+
+import static org.cdpg.dx.database.elastic.util.Constants.ACCESS_POLICY;
+import static org.cdpg.dx.tgdex.search.controller.SearchController.CLAIM_SUBJECT;
+import static org.cdpg.dx.tgdex.util.Constants.*;
+
+import io.vertx.core.json.JsonObject;
+import java.util.List;
+import java.util.Map;
+import org.cdpg.dx.database.elastic.util.QueryType;
+
+public class AccessPolicyQueryDecorator implements ElasticsearchQueryDecorator {
+
+  private final Map<FilterType, List<QueryModel>> queryMap;
+  private final JsonObject request;
+
+  public AccessPolicyQueryDecorator(Map<FilterType, List<QueryModel>> queryMap, JsonObject request) {
+    this.queryMap = queryMap;
+    this.request = request;
+  }
+
+  @Override
+  public Map<FilterType, List<QueryModel>> add() {
+    String sub = request.getString(CLAIM_SUBJECT);
+
+    if (sub != null && !sub.isEmpty()) {
+      // User is authenticated → allow: PUBLIC, RESTRICTED, PRIVATE owned
+
+      // public
+      QueryModel publicAccess = new QueryModel(QueryType.MATCH)
+          .setQueryParameters(Map.of(FIELD, ACCESS_POLICY, VALUE, OPEN));
+
+      // restricted
+      QueryModel restrictedAccess = new QueryModel(QueryType.MATCH)
+          .setQueryParameters(Map.of(FIELD, ACCESS_POLICY, VALUE, RESTRICTED));
+
+      // private
+      QueryModel privateAccess = new QueryModel(QueryType.MATCH)
+          .setQueryParameters(Map.of(FIELD, ACCESS_POLICY, VALUE, PRIVATE));
+
+      // owner match
+      QueryModel ownerMatch = new QueryModel(QueryType.MATCH)
+          .setQueryParameters(Map.of(FIELD, PROVIDER_USER_ID, VALUE, sub));
+
+      // private AND owned
+      QueryModel privateOwned = new QueryModel(QueryType.BOOL)
+          .setMustQueries(List.of(privateAccess, ownerMatch));
+
+      // OR clause: public OR restricted OR private+owned
+      QueryModel accessFilter = new QueryModel(QueryType.BOOL);
+      accessFilter.setShouldQueries(List.of(publicAccess, restrictedAccess, privateOwned));
+      accessFilter.setMinimumShouldMatch("1");
+
+      queryMap.get(FilterType.MUST).add(accessFilter);
+
+    } else {
+      // Not authenticated → exclude PRIVATE
+      QueryModel excludePrivate = new QueryModel(QueryType.MATCH)
+          .setQueryParameters(Map.of(FIELD, ACCESS_POLICY, VALUE, PRIVATE));
+
+      queryMap.get(FilterType.MUST_NOT).add(excludePrivate);
+    }
+
+    return queryMap;
+  }
+}
+

--- a/src/main/java/org/cdpg/dx/database/elastic/model/ElasticsearchResponse.java
+++ b/src/main/java/org/cdpg/dx/database/elastic/model/ElasticsearchResponse.java
@@ -8,6 +8,7 @@ public class ElasticsearchResponse {
   private static JsonObject aggregations;
   private String docId;
   private JsonObject source;
+  private static int totalHits;
 
   public ElasticsearchResponse() {
     // Default constructor
@@ -28,6 +29,14 @@ public class ElasticsearchResponse {
 
   public static void setAggregations(JsonObject aggregations) {
     ElasticsearchResponse.aggregations = aggregations;
+  }
+
+  public static int getTotalHits() {
+    return totalHits;
+  }
+
+  public static void setTotalHits(int totalHits) {
+    ElasticsearchResponse.totalHits = totalHits;
   }
 
   public JsonObject toJson() {
@@ -54,6 +63,8 @@ public class ElasticsearchResponse {
 
   @Override
   public String toString() {
-    return "ElasticsearchResponse{" + "docId='" + docId + '\'' + ", source=" + source + '}';
+    return "ElasticsearchResponse{" + "docId='" + docId + '\'' + "totalHits='" + totalHits + '\'' +
+        ", " +
+        "source=" + source + '}';
   }
 }

--- a/src/main/java/org/cdpg/dx/database/elastic/model/SearchCriteriaQueryDecorator.java
+++ b/src/main/java/org/cdpg/dx/database/elastic/model/SearchCriteriaQueryDecorator.java
@@ -32,7 +32,7 @@ public class SearchCriteriaQueryDecorator implements ElasticsearchQueryDecorator
     if (!request.containsKey(SEARCH_CRITERIA_KEY)) {
       return queryMap;
     }
-    LOGGER.info("Adding searchCriteria query decorator "+request) ;
+    LOGGER.info("Adding searchCriteria query decorator " + request) ;
     JsonArray criteria = request.getJsonArray(SEARCH_CRITERIA_KEY);
     if (criteria == null || criteria.isEmpty()) {
       throw new DxEsException("Invalid Property Value: Empty searchCriteria");
@@ -144,7 +144,6 @@ public class SearchCriteriaQueryDecorator implements ElasticsearchQueryDecorator
 
     QueryModel queryModel = new QueryModel(QueryType.BOOL);
     queryModel.setShouldQueries(shouldQueries);
-    queryModel.setMinimumShouldMatch("1");
     return queryModel;
   }
 

--- a/src/main/java/org/cdpg/dx/database/elastic/service/ElasticsearchService.java
+++ b/src/main/java/org/cdpg/dx/database/elastic/service/ElasticsearchService.java
@@ -19,7 +19,7 @@ public interface ElasticsearchService {
     return new ElasticsearchServiceVertxEBProxy(vertx, address);
   }
 
-  Future<List<ElasticsearchResponse>> search(String index, QueryModel queryModel);
+  Future<List<ElasticsearchResponse>> search(String index, QueryModel queryModel, String options);
 
   Future<Integer> count(String index, QueryModel queryModel);
 }

--- a/src/main/java/org/cdpg/dx/tgdex/list/controller/ListController.java
+++ b/src/main/java/org/cdpg/dx/tgdex/list/controller/ListController.java
@@ -10,6 +10,7 @@ import org.cdpg.dx.common.response.ResponseBuilder;
 import org.cdpg.dx.tgdex.apiserver.ApiController;
 import org.cdpg.dx.tgdex.list.service.ListService;
 
+import static org.cdpg.dx.tgdex.util.Constants.RESULTS;
 import static org.cdpg.dx.util.Constants.*;
 
 public class ListController implements ApiController {
@@ -38,7 +39,9 @@ public class ListController implements ApiController {
             return;
         }
     listService.getAvailableFilters(requestBody).onSuccess(successHandler -> {
-        ResponseBuilder.sendSuccess(routingContext, successHandler.getResponse(), successHandler.getPaginationInfo());
+        ResponseBuilder.sendSuccess(routingContext, successHandler.getResponse().getJsonArray(
+            RESULTS),
+            successHandler.getPaginationInfo());
     }).onFailure(failureHandler -> {
         LOGGER.error("Failed to fetch activity logs: {}", failureHandler.getMessage(), failureHandler);
         routingContext.fail(failureHandler);

--- a/src/main/java/org/cdpg/dx/tgdex/list/service/ListServiceImpl.java
+++ b/src/main/java/org/cdpg/dx/tgdex/list/service/ListServiceImpl.java
@@ -39,12 +39,12 @@ public class ListServiceImpl implements ListService{
         }
 
         return validatorService.validateSearchQuery(body)
-                .compose(validated -> {
-                    QueryModel queryModel = queryDecoder.listMultipleItemTypesQuery(body);
-                    return elasticsearchService.search(docIndex, queryModel);
-                })
-                .map(ResponseModel::new)
-                .onFailure(err -> LOGGER.error("Search execution failed: {}", err.getMessage()));
+            .compose(validated -> {
+                QueryModel queryModel = queryDecoder.listMultipleItemTypesQuery(body);
+                return elasticsearchService.search(docIndex, queryModel, "AGGREGATION_LIST");
+            })
+            .map(ResponseModel::new)
+            .onFailure(err -> LOGGER.error("Search execution failed: {}", err.getMessage()));
 
     }
 

--- a/src/main/java/org/cdpg/dx/tgdex/search/controller/SearchController.java
+++ b/src/main/java/org/cdpg/dx/tgdex/search/controller/SearchController.java
@@ -23,7 +23,7 @@ import static org.cdpg.dx.util.Constants.POST_SEARCH;
  */
 public class SearchController implements ApiController {
     private static final Logger LOGGER = LogManager.getLogger(SearchController.class);
-    private static final String CLAIM_SUBJECT = "sub";
+    public static final String CLAIM_SUBJECT = "sub";
 
     private final SearchService searchService;
     private final AuditingHandler auditingHandler;

--- a/src/main/java/org/cdpg/dx/tgdex/search/service/SearchServiceImpl.java
+++ b/src/main/java/org/cdpg/dx/tgdex/search/service/SearchServiceImpl.java
@@ -43,21 +43,13 @@ public class SearchServiceImpl implements SearchService {
             LOGGER.error("Invalid search request: {}", e.getMessage());
             return Future.failedFuture(e);
         }
-//        QueryModel queryModel = queryDecoder.getQueryModel(requestBody);
-
-//        return elasticsearchService.search(docIndex, queryModel)
-//            .map(results -> new ResponseModel(
-//            results,
-//            requestBody.getInteger(SIZE_KEY),
-//                        requestBody.getInteger(PAGE_KEY)
-//            ));
 
         // Validate, then search, then map to ResponseModel
         return validatorService.validateSearchQuery(requestBody)
                 .compose(validated -> {
                     requestBody.put(SEARCH,true);
                     QueryModel queryModel = queryDecoder.getQueryModel(requestBody);
-                    return elasticsearchService.search(docIndex, queryModel);
+                    return elasticsearchService.search(docIndex, queryModel, "SOURCE");
                 })
                 .map(results -> new ResponseModel(
                         results,

--- a/src/main/java/org/cdpg/dx/tgdex/search/util/ResponseModel.java
+++ b/src/main/java/org/cdpg/dx/tgdex/search/util/ResponseModel.java
@@ -1,78 +1,90 @@
 package org.cdpg.dx.tgdex.search.util;
 
+import static org.cdpg.dx.tgdex.util.Constants.RESULTS;
+
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import org.cdpg.dx.common.util.PaginationInfo;
-import org.cdpg.dx.database.elastic.model.ElasticsearchResponse;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import org.cdpg.dx.common.util.PaginationInfo;
+import org.cdpg.dx.database.elastic.model.ElasticsearchResponse;
 
 public class ResponseModel {
-    JsonObject response;
+  private final List<JsonObject> elasticsearchResponses;
+  JsonObject response;
+  private int totalHits;
+  private PaginationInfo paginationInfo;
 
-    public List<JsonObject> getElasticsearchResponses() {
-        return elasticsearchResponses;
-    }
+  public ResponseModel(List<ElasticsearchResponse> elasticsearchResponses, int size, int page) {
+    this.response = new JsonObject();
+    this.response.put(RESULTS, elasticsearchResponses);
+    setTotalHits(ElasticsearchResponse.getTotalHits());
+    this.elasticsearchResponses =
+        getJsonObjectList(Objects.requireNonNullElse(elasticsearchResponses, List.of()));
+    setPaginationInfo(page, size);
+    setResponseJson();
+  }
 
-    private List<JsonObject> elasticsearchResponses;
-    private int totalHits;
-    private PaginationInfo paginationInfo;
+  public ResponseModel(List<ElasticsearchResponse> elasticsearchResponses) {
+    this.elasticsearchResponses =
+        getJsonObjectList(Objects.requireNonNullElse(elasticsearchResponses, List.of()));
+    this.response = new JsonObject();
+    this.response.put(RESULTS, setAggregationsList());
+  }
 
-    public ResponseModel(List<ElasticsearchResponse> elasticsearchResponses, int size,int page) {
-        this.response=new JsonObject();
-        this.response.put("results",elasticsearchResponses);
-        this.elasticsearchResponses = getJsonObjectList(Objects.requireNonNullElse(elasticsearchResponses, List.of()));
-        setPaginationInfo(page,size);
-        setResponseJson();
-    }
+  private JsonArray setAggregationsList() {
+    JsonArray results = new JsonArray();
+    // Fetch all aggregations from the response JSON
+    JsonObject aggregations = ElasticsearchResponse.getAggregations();
+    results.add(aggregations);
+    return results;
+  }
 
-    public ResponseModel(List<ElasticsearchResponse> elasticsearchResponses) {
-        this.response=new JsonObject();
-        this.response.put("results",elasticsearchResponses);
-        this.elasticsearchResponses = getJsonObjectList(Objects.requireNonNullElse(elasticsearchResponses, List.of()));
-    }
+  public List<JsonObject> getElasticsearchResponses() {
+    return elasticsearchResponses;
+  }
 
-    private void setPaginationInfo(int page, int size) {
-        int totalPages = (int) Math.ceil((double) this.totalHits / size);
-        boolean hasNext = page < totalPages;
-        boolean hasPrevious = page > 1;
-        this.paginationInfo = new PaginationInfo(page, size, this.totalHits, totalPages, hasNext, hasPrevious);
-    }
+  private void setPaginationInfo(int page, int size) {
+    int totalPages = (int) Math.ceil((double) this.totalHits / size);
+    boolean hasNext = page < totalPages;
+    boolean hasPrevious = page > 1;
+    this.paginationInfo =
+        new PaginationInfo(page, size, this.totalHits, totalPages, hasNext, hasPrevious);
+  }
 
-    private List<JsonObject> getJsonObjectList(List<ElasticsearchResponse> elasticsearchResponses) {
-        List<JsonObject> jsonObjectList = new ArrayList<>();
-        for (ElasticsearchResponse elasticsearchResponse : elasticsearchResponses) {
-            jsonObjectList.add(elasticsearchResponse.getSource());
-        }
-        setTotalHits(elasticsearchResponses.size());
-        return jsonObjectList;
+  private List<JsonObject> getJsonObjectList(List<ElasticsearchResponse> elasticsearchResponses) {
+    List<JsonObject> jsonObjectList = new ArrayList<>();
+    for (ElasticsearchResponse elasticsearchResponse : elasticsearchResponses) {
+      jsonObjectList.add(elasticsearchResponse.getSource());
     }
+    return jsonObjectList;
+  }
 
-    public JsonObject getResponse() {
-        return response;
-    }
+  public JsonObject getResponse() {
+    return response;
+  }
 
-    public void setResponseJson(){
-        response = new JsonObject().put("results",elasticsearchResponses);
-    }
+  public void setResponseJson() {
+    response = new JsonObject().put(RESULTS, elasticsearchResponses);
+  }
 
-    public int getTotalHits() {
-        return totalHits;
-    }
+  public int getTotalHits() {
+    return totalHits;
+  }
 
-    public void setTotalHits(int totalHits) {
-        this.totalHits = totalHits;
-    }
-    @Override
-    public String toString() {
-        return "ResponseModel{" +
-                "elasticsearchResponses=" + elasticsearchResponses +
-                '}';
-    }
+  public void setTotalHits(int totalHits) {
+    this.totalHits = totalHits;
+  }
 
-    public PaginationInfo getPaginationInfo() {
-        return paginationInfo;
-    }
+  @Override
+  public String toString() {
+    return "ResponseModel{" +
+        "elasticsearchResponses=" + elasticsearchResponses +
+        '}';
+  }
+
+  public PaginationInfo getPaginationInfo() {
+    return paginationInfo;
+  }
 }

--- a/src/main/java/org/cdpg/dx/tgdex/util/Constants.java
+++ b/src/main/java/org/cdpg/dx/tgdex/util/Constants.java
@@ -82,6 +82,9 @@ public class Constants {
 
     public static final String PROPERTY = "property";
     public static final String VALUE = "value";
+    public static final String OPEN = "OPEN";
+    public static final String PRIVATE = "PRIVATE";
+    public static final String RESTRICTED = "RESTRICTED";
 
     /** GeoRels. */
     public static final String GEOREL_WITHIN = "within";


### PR DESCRIPTION
- Integrated AccessPolicyQueryDecorator into search query flow to enforce access control:
  - Authenticated users can view PUBLIC, RESTRICTED, and their own PRIVATE resources.
  - Unauthenticated users are restricted from accessing PRIVATE resources.
- Extended ElasticsearchServiceImpl#search to support aggregation-only and mixed response modes via options (e.g., AGGREGATION_LIST).
- Parsed aggregation buckets and stored them using ElasticsearchResponse#setAggregations.
- Updated ResponseModel to consume and return aggregations from static context.
- getAvailableFilters now returns structured aggregation response in the format:
  {
    "results": [
      {
      "tags": ["iot", "ml", "ai"],
      ...
    ]
  }
- Matches functionality of legacy ElasticClient#searchAsync for aggregation-based responses.
