### PR TITLE
Fix Search Response:  Exclude summary Key and Return Only Filter-Specified Fields

### DIFF
--- a/src/main/java/org/cdpg/dx/database/elastic/model/QueryDecoder.java
+++ b/src/main/java/org/cdpg/dx/database/elastic/model/QueryDecoder.java
@@ -72,6 +72,12 @@ public class QueryDecoder {
       return q;
     }
 
+    for (QueryModel qm : queryMap.get(FilterType.FILTER)) {
+      if (qm.getIncludeFields() != null) {
+        q.setIncludeFields(qm.getIncludeFields());
+      }
+    }
+
     return q;
   }
 
@@ -135,7 +141,7 @@ public class QueryDecoder {
             VALUE, itemType
         )),
         new QueryModel(QueryType.TERM).setQueryParameters(Map.of(
-            FIELD, "dataUploadStatus",
+            FIELD, DATA_UPLOAD_STATUS,
             VALUE, false
         ))
     ));

--- a/src/main/java/org/cdpg/dx/database/elastic/service/ElasticsearchServiceImpl.java
+++ b/src/main/java/org/cdpg/dx/database/elastic/service/ElasticsearchServiceImpl.java
@@ -1,7 +1,19 @@
 package org.cdpg.dx.database.elastic.service;
 
 import static org.cdpg.dx.database.elastic.util.Constants.AGGREGATIONS;
+import static org.cdpg.dx.database.elastic.util.Constants.AGGREGATION_LIST;
+import static org.cdpg.dx.database.elastic.util.Constants.AGGREGATION_ONLY;
+import static org.cdpg.dx.database.elastic.util.Constants.BUCKETS;
+import static org.cdpg.dx.database.elastic.util.Constants.DOC_IDS_ONLY;
+import static org.cdpg.dx.database.elastic.util.Constants.ID;
+import static org.cdpg.dx.database.elastic.util.Constants.KEY;
+import static org.cdpg.dx.database.elastic.util.Constants.SOURCE;
+import static org.cdpg.dx.database.elastic.util.Constants.SOURCE_AND_ID;
+import static org.cdpg.dx.database.elastic.util.Constants.SOURCE_AND_ID_GEOQUERY;
+import static org.cdpg.dx.database.elastic.util.Constants.SOURCE_ONLY;
 import static org.cdpg.dx.database.elastic.util.Constants.STRING_SIZE;
+import static org.cdpg.dx.database.elastic.util.Constants.SUMMARY_KEY;
+import static org.cdpg.dx.database.elastic.util.Constants.WORD_VECTOR_KEY;
 
 import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
 import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
@@ -11,6 +23,9 @@ import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.JsonpMapperFeatures;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
@@ -22,7 +37,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.cdpg.dx.common.exception.DxBadRequestException;
@@ -100,28 +114,36 @@ public class ElasticsearchServiceImpl implements ElasticsearchService {
         JsonObject aggregationsJson = new JsonObject();
 
         // 1. Handle hits if needed
-        if (!options.startsWith("AGGREGATION")) {
+        if (!options.startsWith(AGGREGATION_ONLY)) {
           for (var hit : response.hits().hits()) {
             String id = hit.id();
             JsonObject source =
-                hit.source() != null ? JsonObject.mapFrom(hit.source()) : new JsonObject();
-
+                hit.source() != null
+                    ? new JsonObject(hit.source().toString())
+                    : new JsonObject();
+            JsonObject result = new JsonObject();
             switch (options) {
-              case "DOC_IDS_ONLY":
-                source = new JsonObject().put("id", id);
+              case DOC_IDS_ONLY:
+                result.put(ID, id);
                 break;
-
-              case "SOURCE_AND_ID":
-                source = new JsonObject().put("id", id).put("source", source);
+              case SOURCE_AND_ID:
+                result.put(ID, id).put(SOURCE, source);
                 break;
-
-              case "SOURCE_ONLY":
+              case SOURCE_AND_ID_GEOQUERY:
+                source.put("doc_id", id);
+                result.mergeIn(source);
+                break;
+              case SOURCE_ONLY:
+                source.remove(SUMMARY_KEY);
+                source.remove(WORD_VECTOR_KEY);
+                result = source;
+                break;
               default:
-                // leave source as-is
+                result = source;
                 break;
             }
 
-            esResponses.add(new ElasticsearchResponse(id, source));
+            esResponses.add(new ElasticsearchResponse(id, result));
           }
 
           long totalHits = response.hits().total() != null ? response.hits().total().value() : 0;
@@ -129,9 +151,8 @@ public class ElasticsearchServiceImpl implements ElasticsearchService {
         }
 
         // 2. Handle aggregations if needed
-        if (options.startsWith("AGGREGATION")) {
+        if (options.startsWith(AGGREGATION_ONLY)) {
           aggregationsJson = parseAggregations(response, options);
-          LOGGER.debug("parsed aggs: " + aggregationsJson);
         }
 
         if (!aggregationsJson.isEmpty()) {
@@ -149,7 +170,7 @@ public class ElasticsearchServiceImpl implements ElasticsearchService {
   }
 
   private int parseSize(String options, QueryModel model) {
-    if (options.startsWith("AGGREGATION")) {
+    if (options.startsWith(AGGREGATION_ONLY)) {
       return 0;
     }
     return model.getLimit() != null ? Integer.parseInt(model.getLimit()) : STRING_SIZE;
@@ -171,17 +192,14 @@ public class ElasticsearchServiceImpl implements ElasticsearchService {
     // Parse the aggregations object from the serialized result
     JsonObject rawAggs = new JsonObject(result).getJsonObject(AGGREGATIONS);
 
-
-    LOGGER.debug("raAggs: " + rawAggs);
-
-    if ("AGGREGATION_LIST".equals(options)) {
+    if (AGGREGATION_LIST.equals(options)) {
       for (String aggKey : rawAggs.fieldNames()) {
         JsonArray keys = new JsonArray();
         JsonObject agg = rawAggs.getJsonObject(aggKey);
-        if (agg.containsKey("buckets")) {
-          JsonArray buckets = agg.getJsonArray("buckets");
+        if (agg.containsKey(BUCKETS)) {
+          JsonArray buckets = agg.getJsonArray(BUCKETS);
           for (int i = 0; i < buckets.size(); i++) {
-            keys.add(buckets.getJsonObject(i).getString("key"));
+            keys.add(buckets.getJsonObject(i).getString(KEY));
           }
         }
         aggResult.put(aggKey, keys);
@@ -189,7 +207,6 @@ public class ElasticsearchServiceImpl implements ElasticsearchService {
     } else {
       aggResult.mergeIn(rawAggs);
     }
-    LOGGER.debug("agg list: " + aggResult);
 
     return aggResult;
   }

--- a/src/main/java/org/cdpg/dx/database/elastic/util/Constants.java
+++ b/src/main/java/org/cdpg/dx/database/elastic/util/Constants.java
@@ -83,6 +83,9 @@ public class Constants {
   public static final String TAG_AQM = "aqm";
   public static final String DESCRIPTION_ATTR = "description";
   public static final String ACCESS_POLICY = "accessPolicy";
+  public static final String OPEN = "OPEN";
+  public static final String PRIVATE = "PRIVATE";
+  public static final String RESTRICTED = "RESTRICTED";
 
   /**
    * OldElasticClient search types.
@@ -94,6 +97,7 @@ public class Constants {
   public static final String FORWARD_SLASH = "/";
   public static final String WILDCARD_KEY = "wildcard";
   public static final String AGGREGATION_ONLY = "AGGREGATION";
+  public static final String AGGREGATION_LIST = "AGGREGATION_LIST";
   public static final String RATING_AGGREGATION_ONLY = "R_AGGREGATION";
   public static final String TYPE_KEYWORD = "type.keyword";
   public static final String WORD_VECTOR_KEY = "_word_vector";
@@ -470,6 +474,7 @@ public class Constants {
   public static final String INCLUDE_FIELDS = "includeFields";
   public static final String FIELD = "field";
   public static final String VALUES = "values";
+  public static final String DATA_UPLOAD_STATUS = "dataUploadStatus";
   public static final String QUERY_KEY = "query";
   public static final String HITS = "hits";
   public static final String TOTAL = "total";

--- a/src/main/java/org/cdpg/dx/tgdex/list/service/ListServiceImpl.java
+++ b/src/main/java/org/cdpg/dx/tgdex/list/service/ListServiceImpl.java
@@ -41,7 +41,7 @@ public class ListServiceImpl implements ListService{
         return validatorService.validateSearchQuery(body)
             .compose(validated -> {
                 QueryModel queryModel = queryDecoder.listMultipleItemTypesQuery(body);
-                return elasticsearchService.search(docIndex, queryModel, "AGGREGATION_LIST");
+                return elasticsearchService.search(docIndex, queryModel, AGGREGATION_LIST);
             })
             .map(ResponseModel::new)
             .onFailure(err -> LOGGER.error("Search execution failed: {}", err.getMessage()));

--- a/src/main/java/org/cdpg/dx/tgdex/search/service/SearchServiceImpl.java
+++ b/src/main/java/org/cdpg/dx/tgdex/search/service/SearchServiceImpl.java
@@ -49,7 +49,7 @@ public class SearchServiceImpl implements SearchService {
                 .compose(validated -> {
                     requestBody.put(SEARCH,true);
                     QueryModel queryModel = queryDecoder.getQueryModel(requestBody);
-                    return elasticsearchService.search(docIndex, queryModel, "SOURCE");
+                    return elasticsearchService.search(docIndex, queryModel, SOURCE_ONLY);
                 })
                 .map(results -> new ResponseModel(
                         results,


### PR DESCRIPTION
### This update fix the search response handling by:

- Excluding the `_summary` key from the response to reduce unnecessary data.

- Returning only those fields explicitly listed in the filter array of the request payload.
