### PR TITLE
Refactor ElasticsearchServiceImpl to unify aggregation handling via search()

### DIFF
--- a/src/main/java/org/cdpg/dx/database/elastic/service/ElasticsearchService.java
+++ b/src/main/java/org/cdpg/dx/database/elastic/service/ElasticsearchService.java
@@ -5,8 +5,6 @@ import io.vertx.codegen.annotations.ProxyGen;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonObject;
-import org.cdpg.dx.database.elastic.model.AggregationResponse;
 import org.cdpg.dx.database.elastic.model.ElasticsearchResponse;
 import org.cdpg.dx.database.elastic.model.QueryModel;
 
@@ -24,6 +22,5 @@ public interface ElasticsearchService {
   Future<List<ElasticsearchResponse>> search(String index, QueryModel queryModel, String options);
 
   Future<Integer> count(String index, QueryModel queryModel);
-  Future<AggregationResponse> countByAggregation(String index, QueryModel queryModel);
 
 }

--- a/src/main/java/org/cdpg/dx/database/elastic/util/Constants.java
+++ b/src/main/java/org/cdpg/dx/database/elastic/util/Constants.java
@@ -98,6 +98,7 @@ public class Constants {
   public static final String WILDCARD_KEY = "wildcard";
   public static final String AGGREGATION_ONLY = "AGGREGATION";
   public static final String AGGREGATION_LIST = "AGGREGATION_LIST";
+  public static final String COUNT_AGGREGATION_ONLY = "COUNT_AGGREGATION";
   public static final String RATING_AGGREGATION_ONLY = "R_AGGREGATION";
   public static final String TYPE_KEYWORD = "type.keyword";
   public static final String WORD_VECTOR_KEY = "_word_vector";

--- a/src/main/java/org/cdpg/dx/tgdex/search/controller/SearchController.java
+++ b/src/main/java/org/cdpg/dx/tgdex/search/controller/SearchController.java
@@ -1,10 +1,23 @@
 package org.cdpg.dx.tgdex.search.controller;
 
+import static org.cdpg.dx.database.elastic.util.Constants.PAGE_KEY;
+import static org.cdpg.dx.database.elastic.util.Constants.SIZE_KEY;
+import static org.cdpg.dx.tgdex.util.Constants.DEFAULT_MAX_PAGE_SIZE;
+import static org.cdpg.dx.tgdex.util.Constants.DEFAULT_PAGE_NUMBER;
+import static org.cdpg.dx.tgdex.util.Constants.MY_ASSETS_REQ;
+import static org.cdpg.dx.tgdex.util.Constants.RESULTS;
+import static org.cdpg.dx.tgdex.util.Constants.SUB;
+import static org.cdpg.dx.util.Constants.ASSET_SEARCH;
+import static org.cdpg.dx.util.Constants.POST_COUNT_SEARCH;
+import static org.cdpg.dx.util.Constants.POST_SEARCH;
+
 import io.vertx.core.Future;
 import io.vertx.core.MultiMap;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.openapi.RouterBuilder;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.cdpg.dx.auditing.handler.AuditingHandler;
@@ -13,138 +26,138 @@ import org.cdpg.dx.tgdex.apiserver.ApiController;
 import org.cdpg.dx.tgdex.search.service.SearchService;
 import org.cdpg.dx.util.CheckIfTokenPresent;
 
-import java.util.function.BiConsumer;
-import java.util.function.Function;
-
-import static org.cdpg.dx.database.elastic.util.Constants.*;
-import static org.cdpg.dx.tgdex.util.Constants.*;
-import static org.cdpg.dx.util.Constants.*;
-
 /**
  * Controller for handling search endpoints.
  */
 public class SearchController implements ApiController {
-    private static final Logger LOGGER = LogManager.getLogger(SearchController.class);
-    private static final CheckIfTokenPresent TOKEN_CHECK = new CheckIfTokenPresent();
+  private static final Logger LOGGER = LogManager.getLogger(SearchController.class);
+  private static final CheckIfTokenPresent TOKEN_CHECK = new CheckIfTokenPresent();
 
-    private final SearchService searchService;
-    private final AuditingHandler auditingHandler;
+  private final SearchService searchService;
+  private final AuditingHandler auditingHandler;
 
-    public SearchController(SearchService searchService, AuditingHandler auditingHandler) {
-        this.searchService = searchService;
-        this.auditingHandler = auditingHandler;
+  public SearchController(SearchService searchService, AuditingHandler auditingHandler) {
+    this.searchService = searchService;
+    this.auditingHandler = auditingHandler;
+  }
+
+  @Override
+  public void register(RouterBuilder builder) {
+    builder.operation(POST_SEARCH)
+        .handler(this::handleSearch)
+        .handler(auditingHandler::handleApiAudit);
+
+    builder.operation(POST_COUNT_SEARCH)
+        .handler(this::handleCount)
+        .handler(auditingHandler::handleApiAudit);
+
+    builder.operation(ASSET_SEARCH)
+        .handler(TOKEN_CHECK)
+        .handler(this::handleAsset)
+        .handler(auditingHandler::handleApiAudit);
+
+    LOGGER.debug("Registered SearchController operations: {}, {}, {}",
+        POST_SEARCH, POST_COUNT_SEARCH, ASSET_SEARCH);
+  }
+
+  private void handleSearch(RoutingContext ctx) {
+    LOGGER.debug("Received POST request on '{}'", POST_SEARCH);
+    process(ctx,
+        searchService::postSearch,
+        (c, resp) -> ResponseBuilder.sendSuccess(c,
+            resp.getElasticsearchResponses(),
+            resp.getPaginationInfo(),
+            resp.getTotalHits()));
+  }
+
+  private void handleCount(RoutingContext ctx) {
+    LOGGER.debug("Received POST Count request on '{}'", POST_COUNT_SEARCH);
+    process(ctx,
+        searchService::postCount,
+        (c, resp) -> ResponseBuilder.sendSuccess(c,
+            resp.getResponse().getJsonArray(RESULTS)));
+  }
+
+  private void handleAsset(RoutingContext ctx) {
+    LOGGER.debug("Received POST Asset request on '{}'", ASSET_SEARCH);
+    JsonObject body = prepareRequestBody(ctx);
+      if (body == null) {
+          return;
+      }
+
+    MultiMap params = ctx.request().params();
+    params.forEach(entry -> body.put(entry.getKey(), entry.getValue()));
+    body.put(MY_ASSETS_REQ, true);
+    LOGGER.debug("Asset request body: {}", body);
+
+    // Reuse search handler logic
+    process(ctx,
+        searchService::postSearch,
+        (c, resp) -> ResponseBuilder.sendSuccess(c,
+            resp.getElasticsearchResponses(),
+            resp.getPaginationInfo(),
+            resp.getTotalHits()));
+  }
+
+  /**
+   * Generic request processor: prepares body, invokes service, and handles success/failure.
+   */
+  private <T> void process(RoutingContext ctx,
+                           Function<JsonObject, Future<T>> serviceCall,
+                           BiConsumer<RoutingContext, T> onSuccess) {
+    JsonObject body = prepareRequestBody(ctx);
+      if (body == null) {
+          return;
+      }
+
+    serviceCall.apply(body)
+        .onSuccess(result -> onSuccess.accept(ctx, result))
+        .onFailure(err -> handleFailure(ctx, err));
+  }
+
+  private JsonObject prepareRequestBody(RoutingContext ctx) {
+    JsonObject body = ctx.getBodyAsJson();
+    if (body == null) {
+      LOGGER.error("Invalid or missing Request body");
+      ctx.fail(400);
+      return null;
     }
+    injectSubject(ctx, body);
+    addPagination(ctx, body);
+    return body;
+  }
 
-    @Override
-    public void register(RouterBuilder builder) {
-        builder.operation(POST_SEARCH)
-                .handler(this::handleSearch)
-                .handler(auditingHandler::handleApiAudit);
-
-        builder.operation(POST_COUNT_SEARCH)
-                .handler(this::handleCount)
-                .handler(auditingHandler::handleApiAudit);
-
-        builder.operation(ASSET_SEARCH)
-                .handler(TOKEN_CHECK)
-                .handler(this::handleAsset)
-                .handler(auditingHandler::handleApiAudit);
-
-        LOGGER.debug("Registered SearchController operations: {}, {}, {}",
-                POST_SEARCH, POST_COUNT_SEARCH, ASSET_SEARCH);
+  private void injectSubject(RoutingContext ctx, JsonObject body) {
+    try {
+      if (ctx.user() != null) {
+        String subject = ctx.user().principal().getString(SUB);
+        body.put(SUB, subject);
+      }
+    } catch (Exception e) {
+      LOGGER.warn("User subject not available: {}", e.getMessage());
     }
+  }
 
-    private void handleSearch(RoutingContext ctx) {
-        LOGGER.debug("Received POST request on '{}'", POST_SEARCH);
-        process(ctx,
-                searchService::postSearch,
-                (c, resp) -> ResponseBuilder.sendSuccess(c,
-                        resp.getElasticsearchResponses(),
-                        resp.getPaginationInfo(),
-                        resp.getTotalHits()));
+  private void addPagination(RoutingContext ctx, JsonObject body) {
+    int size = parseOrDefault(ctx.request().getParam(SIZE_KEY), DEFAULT_MAX_PAGE_SIZE);
+    int page = parseOrDefault(ctx.request().getParam(PAGE_KEY), DEFAULT_PAGE_NUMBER);
+    body.put(SIZE_KEY, size).put(PAGE_KEY, page);
+  }
+
+  private int parseOrDefault(String val, int defaultVal) {
+      if (val == null) {
+          return defaultVal;
+      }
+    try {
+      return Integer.parseInt(val);
+    } catch (NumberFormatException e) {
+      LOGGER.warn("Invalid integer '{}', using default {}", val, defaultVal);
+      return defaultVal;
     }
+  }
 
-    private void handleCount(RoutingContext ctx) {
-        LOGGER.debug("Received POST Count request on '{}'", POST_COUNT_SEARCH);
-        process(ctx,
-                searchService::postCount,
-                (c, results) -> ResponseBuilder.sendSuccess(c, results.getResults()));
-    }
-
-    private void handleAsset(RoutingContext ctx) {
-        LOGGER.debug("Received POST Asset request on '{}'", ASSET_SEARCH);
-        JsonObject body = prepareRequestBody(ctx);
-        if (body == null) return;
-
-        MultiMap params = ctx.request().params();
-        params.forEach(entry -> body.put(entry.getKey(), entry.getValue()));
-        body.put(MY_ASSETS_REQ, true);
-        LOGGER.debug("Asset request body: {}", body);
-
-        // Reuse search handler logic
-        process(ctx,
-                searchService::postSearch,
-                (c, resp) -> ResponseBuilder.sendSuccess(c,
-                        resp.getElasticsearchResponses(),
-                        resp.getPaginationInfo(),
-                        resp.getTotalHits()));
-    }
-
-    /**
-     * Generic request processor: prepares body, invokes service, and handles success/failure.
-     */
-    private <T> void process(RoutingContext ctx,
-                             Function<JsonObject, Future<T>> serviceCall,
-                             BiConsumer<RoutingContext, T> onSuccess) {
-        JsonObject body = prepareRequestBody(ctx);
-        if (body == null) return;
-
-        serviceCall.apply(body)
-                .onSuccess(result -> onSuccess.accept(ctx, result))
-                .onFailure(err -> handleFailure(ctx, err));
-    }
-
-    private JsonObject prepareRequestBody(RoutingContext ctx) {
-        JsonObject body = ctx.getBodyAsJson();
-        if (body == null) {
-            LOGGER.error("Invalid or missing Request body");
-            ctx.fail(400);
-            return null;
-        }
-        injectSubject(ctx, body);
-        addPagination(ctx, body);
-        return body;
-    }
-
-    private void injectSubject(RoutingContext ctx, JsonObject body) {
-        try {
-            if (ctx.user() != null) {
-                String subject = ctx.user().principal().getString(SUB);
-                body.put(SUB, subject);
-            }
-        } catch (Exception e) {
-            LOGGER.warn("User subject not available: {}", e.getMessage());
-        }
-    }
-
-    private void addPagination(RoutingContext ctx, JsonObject body) {
-        int size = parseOrDefault(ctx.request().getParam(SIZE_KEY), DEFAULT_MAX_PAGE_SIZE);
-        int page = parseOrDefault(ctx.request().getParam(PAGE_KEY), DEFAULT_PAGE_NUMBER);
-        body.put(SIZE_KEY, size).put(PAGE_KEY, page);
-    }
-
-    private int parseOrDefault(String val, int defaultVal) {
-        if (val == null) return defaultVal;
-        try {
-            return Integer.parseInt(val);
-        } catch (NumberFormatException e) {
-            LOGGER.warn("Invalid integer '{}', using default {}", val, defaultVal);
-            return defaultVal;
-        }
-    }
-
-    private void handleFailure(RoutingContext ctx, Throwable err) {
-        LOGGER.error("Search request failed: {}", err.getMessage(), err);
-        ctx.fail(err);
-    }
+  private void handleFailure(RoutingContext ctx, Throwable err) {
+    LOGGER.error("Search request failed: {}", err.getMessage(), err);
+    ctx.fail(err);
+  }
 }

--- a/src/main/java/org/cdpg/dx/tgdex/search/service/SearchService.java
+++ b/src/main/java/org/cdpg/dx/tgdex/search/service/SearchService.java
@@ -9,5 +9,5 @@ import org.cdpg.dx.tgdex.search.util.ResponseModel;
 public interface SearchService {
 
     Future<ResponseModel> postSearch(JsonObject requestBody);
-    Future<AggregationResponse> postCount(JsonObject requestBody);
+    Future<ResponseModel> postCount(JsonObject requestBody);
 }

--- a/src/main/java/org/cdpg/dx/tgdex/search/service/SearchServiceImpl.java
+++ b/src/main/java/org/cdpg/dx/tgdex/search/service/SearchServiceImpl.java
@@ -1,118 +1,133 @@
 package org.cdpg.dx.tgdex.search.service;
 
+import static org.cdpg.dx.database.elastic.util.Constants.COUNT_AGGREGATION_ONLY;
+import static org.cdpg.dx.database.elastic.util.Constants.FILTER;
+import static org.cdpg.dx.database.elastic.util.Constants.PAGE_KEY;
+import static org.cdpg.dx.database.elastic.util.Constants.Q_VALUE;
+import static org.cdpg.dx.database.elastic.util.Constants.RESPONSE_FILTER;
+import static org.cdpg.dx.database.elastic.util.Constants.SEARCH;
+import static org.cdpg.dx.database.elastic.util.Constants.SEARCH_CRITERIA_KEY;
+import static org.cdpg.dx.database.elastic.util.Constants.SEARCH_TYPE;
+import static org.cdpg.dx.database.elastic.util.Constants.SEARCH_TYPE_CRITERIA;
+import static org.cdpg.dx.database.elastic.util.Constants.SEARCH_TYPE_TEXT;
+import static org.cdpg.dx.database.elastic.util.Constants.SIZE_KEY;
+import static org.cdpg.dx.database.elastic.util.Constants.SOURCE_ONLY;
+
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
+import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.cdpg.dx.common.exception.DxBadRequestException;
-import org.cdpg.dx.database.elastic.model.AggregationResponse;
 import org.cdpg.dx.database.elastic.model.QueryDecoder;
 import org.cdpg.dx.database.elastic.model.QueryModel;
 import org.cdpg.dx.database.elastic.service.ElasticsearchService;
 import org.cdpg.dx.tgdex.search.util.ResponseModel;
 import org.cdpg.dx.tgdex.validator.service.ValidatorService;
 
-import java.util.List;
-
-import static org.cdpg.dx.database.elastic.util.Constants.*;
-
 public class SearchServiceImpl implements SearchService {
-    private static final Logger LOGGER = LogManager.getLogger(SearchServiceImpl.class);
+  private static final Logger LOGGER = LogManager.getLogger(SearchServiceImpl.class);
 
-    private final ElasticsearchService elasticsearchService;
-    private final QueryDecoder queryDecoder;
-    private final String docIndex;
-    private final ValidatorService validatorService;
+  private final ElasticsearchService elasticsearchService;
+  private final QueryDecoder queryDecoder;
+  private final String docIndex;
+  private final ValidatorService validatorService;
 
-    public SearchServiceImpl(ElasticsearchService elasticsearchService, String docIndex, ValidatorService validatorService) {
-        this.elasticsearchService = elasticsearchService;
-        this.queryDecoder = new QueryDecoder();
-        this.docIndex = docIndex;
-        this.validatorService = validatorService;
+  public SearchServiceImpl(ElasticsearchService elasticsearchService, String docIndex,
+                           ValidatorService validatorService) {
+    this.elasticsearchService = elasticsearchService;
+    this.queryDecoder = new QueryDecoder();
+    this.docIndex = docIndex;
+    this.validatorService = validatorService;
+  }
+
+  @Override
+  public Future<ResponseModel> postSearch(JsonObject requestBody) {
+    try {
+      setSearchType(requestBody);
+    } catch (DxBadRequestException e) {
+      LOGGER.error("Invalid search request: {}", e.getMessage());
+      return Future.failedFuture(e);
     }
 
-    @Override
-    public Future<ResponseModel> postSearch(JsonObject requestBody) {
-        try {
-            setSearchType(requestBody);
-        } catch (DxBadRequestException e) {
-            LOGGER.error("Invalid search request: {}", e.getMessage());
-            return Future.failedFuture(e);
-        }
+    return validatorService.validateSearchQuery(requestBody).compose(validated -> {
+          requestBody.put(SEARCH, true);
+          QueryModel queryModel = queryDecoder.getQueryModel(requestBody);
+          return elasticsearchService.search(docIndex, queryModel, SOURCE_ONLY);
+        }).map(results -> new ResponseModel(results, getIntValue(requestBody, SIZE_KEY),
+            getIntValue(requestBody, PAGE_KEY)))
+        .onFailure(err -> LOGGER.error("Search execution failed: {}", err.getMessage()));
+  }
 
-        return validatorService.validateSearchQuery(requestBody).compose(validated -> {
-            requestBody.put(SEARCH, true);
-            QueryModel queryModel = queryDecoder.getQueryModel(requestBody);
-            return elasticsearchService.search(docIndex, queryModel, SOURCE_ONLY);
-        }).map(results -> new ResponseModel(results, getIntValue(requestBody, SIZE_KEY), getIntValue(requestBody, PAGE_KEY))).onFailure(err -> LOGGER.error("Search execution failed: {}", err.getMessage()));
+  @Override
+  public Future<ResponseModel> postCount(JsonObject requestBody) {
+    try {
+      setSearchType(requestBody);
+    } catch (DxBadRequestException e) {
+      LOGGER.error("Invalid search request: {}", e.getMessage());
+      return Future.failedFuture(e);
     }
 
-    @Override
-    public Future<AggregationResponse> postCount(JsonObject requestBody) {
-        try {
-            setSearchType(requestBody);
-        } catch (DxBadRequestException e) {
-            LOGGER.error("Invalid search request: {}", e.getMessage());
-            return Future.failedFuture(e);
-        }
+    return validatorService.validateSearchQuery(requestBody).compose(validated -> {
+          QueryModel queryModel = queryDecoder.getQueryModel(requestBody);
+          queryModel.setAggregations(List.of(queryDecoder.setCountAggregations()));
+          return elasticsearchService.search(docIndex, queryModel, COUNT_AGGREGATION_ONLY);
+        }).map(ResponseModel::new)
+        .onFailure(err -> LOGGER.error("Count execution failed: {}", err.getMessage()));
+  }
 
-        return validatorService.validateSearchQuery(requestBody).compose(validated -> {
-            QueryModel queryModel = queryDecoder.getQueryModel(requestBody);
-            queryModel.setAggregations(List.of(queryDecoder.setCountAggregations()));
-            return elasticsearchService.countByAggregation(docIndex, queryModel);
-        }).onFailure(err -> LOGGER.error("Count execution failed: {}", err.getMessage()));
+  /**
+   * Sets the SEARCH_TYPE in the request body based on present filters.
+   *
+   * @throws DxBadRequestException if no valid filter is provided.
+   */
+  private void setSearchType(JsonObject body) {
+    String searchType = buildSearchType(body);
+    LOGGER.info("search type {}", searchType);
+    body.put(SEARCH_TYPE, searchType);
+  }
+
+  /**
+   * Builds the SEARCH_TYPE string based on present filters in the request body.
+   *
+   * @throws DxBadRequestException if no valid filter is provided.
+   */
+  private String buildSearchType(JsonObject body) {
+    boolean hasFilter = false;
+    StringBuilder typeBuilder = new StringBuilder();
+
+    if (body.getJsonArray(SEARCH_CRITERIA_KEY) != null &&
+        !body.getJsonArray(SEARCH_CRITERIA_KEY).isEmpty()) {
+      typeBuilder.append(SEARCH_TYPE_CRITERIA);
+      hasFilter = true;
     }
-
-    /**
-     * Sets the SEARCH_TYPE in the request body based on present filters.
-     *
-     * @throws DxBadRequestException if no valid filter is provided.
-     */
-    private void setSearchType(JsonObject body) {
-        String searchType = buildSearchType(body);
-        LOGGER.info("search type {}", searchType);
-        body.put(SEARCH_TYPE, searchType);
+    if (body.getString(Q_VALUE) != null && !body.getString(Q_VALUE).isBlank()) {
+      typeBuilder.append(SEARCH_TYPE_TEXT);
+      hasFilter = true;
     }
-
-    /**
-     * Builds the SEARCH_TYPE string based on present filters in the request body.
-     *
-     * @throws DxBadRequestException if no valid filter is provided.
-     */
-    private String buildSearchType(JsonObject body) {
-        boolean hasFilter = false;
-        StringBuilder typeBuilder = new StringBuilder();
-
-        if (body.getJsonArray(SEARCH_CRITERIA_KEY) != null && !body.getJsonArray(SEARCH_CRITERIA_KEY).isEmpty()) {
-            typeBuilder.append(SEARCH_TYPE_CRITERIA);
-            hasFilter = true;
-        }
-        if (body.getString(Q_VALUE) != null && !body.getString(Q_VALUE).isBlank()) {
-            typeBuilder.append(SEARCH_TYPE_TEXT);
-            hasFilter = true;
-        }
-        if (body.containsKey(FILTER) && body.getJsonArray(FILTER) != null && !body.getJsonArray(FILTER).isEmpty()) {
-            typeBuilder.append(RESPONSE_FILTER);
-            hasFilter = true;
-        }
-        if (!hasFilter) {
-            throw new DxBadRequestException("Mandatory field(s) not provided");
-        }
-        return typeBuilder.toString();
+    if (body.containsKey(FILTER) && body.getJsonArray(FILTER) != null &&
+        !body.getJsonArray(FILTER).isEmpty()) {
+      typeBuilder.append(RESPONSE_FILTER);
+      hasFilter = true;
     }
+    if (!hasFilter) {
+      throw new DxBadRequestException("Mandatory field(s) not provided");
+    }
+    return typeBuilder.toString();
+  }
 
-    private Integer getIntValue(JsonObject obj, String key) {
-        Object value = obj.getValue(key);
-        if (value instanceof Integer) {
-            return (Integer) value;
-        } else if (value instanceof String) {
-            try {
-                return Integer.parseInt((String) value);
-            } catch (NumberFormatException e) {
-                LOGGER.warn("Invalid integer format for key {}: {}", key, value);
-                return null;
-            }
-        }
+  private Integer getIntValue(JsonObject obj, String key) {
+    Object value = obj.getValue(key);
+    if (value instanceof Integer) {
+      return (Integer) value;
+    } else if (value instanceof String) {
+      try {
+        return Integer.parseInt((String) value);
+      } catch (NumberFormatException e) {
+        LOGGER.warn("Invalid integer format for key {}: {}", key, value);
         return null;
+      }
     }
+    return null;
+  }
 }


### PR DESCRIPTION
### Summary
Removed the `countByAggregation()` method from `ElasticsearchServiceImpl` and integrated its logic into the existing `search()` method using the new option `COUNT_AGGREGATION_ONLY`. This simplifies the service by consolidating all search and aggregation logic into a single entry point.

### Key Changes
- Introduced a new `COUNT_AGGREGATION_ONLY` option to trigger bucket-count aggregation logic.
- Enhanced `parseAggregations()` to differentiate between full aggregation, aggregation list, and count aggregation responses.
- Removed redundant method `countByAggregation()`, reducing code duplication.

### Benefits
- Unified query handling with fewer branching points.
- Easier to maintain and test a single flow for all types of aggregation.
- Improved clarity and flexibility for future extensions (e.g., pagination or other aggregation types).
