### PR TITLE
Fix: Correct validation logic for item existence in POST requests

### DIFF
--- a/src/main/java/org/cdpg/dx/tgdex/item/controller/ItemController.java
+++ b/src/main/java/org/cdpg/dx/tgdex/item/controller/ItemController.java
@@ -86,7 +86,6 @@ public class ItemController implements ApiController {
     JsonObject doc = injectKeycloakInfoIfApplicable(ctx, body, itemType);
 
     String method = ctx.request().method().toString();
-    doc.put(HTTP_METHOD, method);
     doc.put(CONTEXT, vocContext);
 
     Promise<JsonObject> validationPromise = Promise.promise();

--- a/src/main/java/org/cdpg/dx/tgdex/item/util/ItemExistenceValidator.java
+++ b/src/main/java/org/cdpg/dx/tgdex/item/util/ItemExistenceValidator.java
@@ -11,7 +11,6 @@ import static org.cdpg.dx.tgdex.util.Constants.ITEM_TYPE_APPS;
 import static org.cdpg.dx.tgdex.util.Constants.ITEM_TYPE_DATA_BANK;
 import static org.cdpg.dx.tgdex.util.Constants.NAME;
 import static org.cdpg.dx.tgdex.util.Constants.REQUEST_POST;
-import static org.cdpg.dx.tgdex.util.Constants.RESULTS;
 import static org.cdpg.dx.tgdex.util.Constants.TYPE;
 import static org.cdpg.dx.tgdex.util.Constants.UUID_PATTERN;
 import static org.cdpg.dx.tgdex.validator.Constants.ACTIVE;
@@ -102,7 +101,15 @@ public class ItemExistenceValidator {
     itemService.itemWithTheNameExists(ITEM_TYPE_AI_MODEL, request.getString(NAME))
         .onFailure(err -> {
           if (err.getMessage().equals(DETAIL_ITEM_NOT_FOUND)) {
-            promise.complete(request);
+            // For POST, if not found, good to proceed
+            if (REQUEST_POST.equalsIgnoreCase(method)) {
+              request.put(DATA_UPLOAD_STATUS,
+                  request.containsKey(MEDIA_URL) && !request.getString(MEDIA_URL).isBlank());
+              request.put(PUBLISH_STATUS, PENDING);
+              promise.complete(request);
+            } else {
+              promise.complete(request);
+            }
           } else {
             LOGGER.debug("Fail: DB Error: " + err.getLocalizedMessage());
             promise.fail(VALIDATION_FAILURE_MSG);
@@ -145,7 +152,15 @@ public class ItemExistenceValidator {
     itemService.itemWithTheNameExists(ITEM_TYPE_DATA_BANK, request.getString(NAME))
         .onFailure(err -> {
           if (err.getMessage().equals(DETAIL_ITEM_NOT_FOUND)) {
-            promise.complete(request);
+            // For POST, if not found, good to proceed
+            if (REQUEST_POST.equalsIgnoreCase(method)) {
+              request.put(DATA_UPLOAD_STATUS,
+                  request.containsKey(MEDIA_URL) && !request.getString(MEDIA_URL).isBlank());
+              request.put(PUBLISH_STATUS, PENDING);
+              promise.complete(request);
+            } else {
+              promise.complete(request);
+            }
           } else {
             LOGGER.debug("Fail: DB Error: " + err.getLocalizedMessage());
             promise.fail(VALIDATION_FAILURE_MSG);


### PR DESCRIPTION
Refactored validateAiModel and validateDataBank methods to correctly handle item existence checks during POST requests. 
- Ensured POST fails if item with same name already exists
- Allowed POST to proceed only if item is not found
- Added proper branching in onFailure block for PUT and POST
